### PR TITLE
Fix ProductCard viewMode prop type error for Netlify deploy

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -11,6 +11,7 @@ interface ProductCardProps {
   product: Product
   priority?: boolean
   layout?: 'default' | 'featured' | 'minimal'
+  viewMode?: 'grid' | 'list'
 }
 
 const ProductCard: React.FC<ProductCardProps> = ({ 

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -14,10 +14,11 @@ interface ProductCardProps {
   viewMode?: 'grid' | 'list'
 }
 
-const ProductCard: React.FC<ProductCardProps> = ({ 
-  product, 
-  priority = false, 
-  layout = 'default' 
+const ProductCard: React.FC<ProductCardProps> = ({
+  product,
+  priority = false,
+  layout = 'default',
+  viewMode = 'grid'
 }) => {
   const { addItem } = useCart()
   const [selectedSize, setSelectedSize] = useState(product.sizes[0])

--- a/lib/generated/prisma/edge.js
+++ b/lib/generated/prisma/edge.js
@@ -253,8 +253,7 @@ const config = {
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
-    "rootEnvPath": "../../../.env",
-    "schemaEnvPath": "../../../.env"
+    "rootEnvPath": null
   },
   "relativePath": "../../../prisma",
   "clientVersion": "6.12.0",
@@ -263,7 +262,7 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
-  "postinstall": false,
+  "postinstall": true,
   "inlineDatasources": {
     "db": {
       "url": {

--- a/lib/generated/prisma/index.js
+++ b/lib/generated/prisma/index.js
@@ -254,8 +254,7 @@ const config = {
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
-    "rootEnvPath": "../../../.env",
-    "schemaEnvPath": "../../../.env"
+    "rootEnvPath": null
   },
   "relativePath": "../../../prisma",
   "clientVersion": "6.12.0",
@@ -264,7 +263,7 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
-  "postinstall": false,
+  "postinstall": true,
   "inlineDatasources": {
     "db": {
       "url": {


### PR DESCRIPTION
## Purpose
The user was attempting to deploy their Snuggles Website project to Netlify but encountered a TypeScript error related to the `viewMode` property not being compatible with the `ProductCardProps` interface. This fix resolves the deployment blocker by properly defining the missing prop type.

## Code changes
- **ProductCard.tsx**: Added `viewMode?: 'grid' | 'list'` to the `ProductCardProps` interface and included it as an optional parameter with default value 'grid' in the component function
- **Prisma generated files**: Updated configuration to remove environment path references and set postinstall to true for better deployment compatibility

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/5771eb4db17144749d8e294c9acedbb2/spark-world)

👀 [Preview Link](https://5771eb4db17144749d8e294c9acedbb2-spark-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5771eb4db17144749d8e294c9acedbb2</projectId>-->
<!--<branchName>spark-world</branchName>-->