### PR TITLE
Fix nodemailer method name from createTransporter to createTransport

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -22,7 +22,7 @@ const createTransporter = () => {
   }
   
   // Default to Gmail
-  return nodemailer.createTransporter({
+  return nodemailer.createTransport({
     service: 'gmail',
     auth: {
       user: process.env.EMAIL_FROM,

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -10,7 +10,7 @@ interface EmailOptions {
 // Create transporter
 const createTransporter = () => {
   if (process.env.EMAIL_PROVIDER === 'smtp') {
-    return nodemailer.createTransporter({
+    return nodemailer.createTransport({
       host: process.env.SMTP_HOST,
       port: parseInt(process.env.SMTP_PORT || '587'),
       secure: process.env.SMTP_SECURE === 'true',


### PR DESCRIPTION
## Purpose
Fix Netlify build failure caused by incorrect nodemailer method name. The user reported a deployment error where the build was failing due to a type error in the email.ts file, specifically that `createTransporter` does not exist on the nodemailer import.

## Code changes
- Updated `nodemailer.createTransporter()` to `nodemailer.createTransport()` in two locations within the `createTransporter` function
- Fixed the method name for both SMTP and Gmail transporter configurations

This resolves the TypeScript error and allows the build to complete successfully.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/b6d5e8f2b4d344078152b18f097a3424/vortex-world)

👀 [Preview Link](https://b6d5e8f2b4d344078152b18f097a3424-vortex-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b6d5e8f2b4d344078152b18f097a3424</projectId>-->
<!--<branchName>vortex-world</branchName>-->